### PR TITLE
Minor Update to French Translations

### DIFF
--- a/reframework/data/Achievement_Progress_Tracker/languages/fr-FR.json
+++ b/reframework/data/Achievement_Progress_Tracker/languages/fr-FR.json
@@ -51,7 +51,7 @@
 			"base_game": "Jeu de Base"
 		},
 		"misc": {
-			"current": "Actuel",
+			"current": "Actuelle",
 			"select_achievements": "Sélectionnez les distinctions à suivre",
 			"completed": "- OBTENUE"
 		},
@@ -62,7 +62,7 @@
 			"adjust_position": "Ajuster la position"
 		},
 		"tooltip": {
-			"manual_input": "CTRL + clic gauche pour saisir manuellement",
+			"manual_input": "Faites un CTRL + Clic gauche sur la barre pour saisir une valeur manuellement",
 			"uncheck_achievement": "Décochez les cases des distinctions que vous ne souhaitez pas suivre"
 		}
 	},

--- a/reframework/data/Achievement_Progress_Tracker/languages/fr-FR.json
+++ b/reframework/data/Achievement_Progress_Tracker/languages/fr-FR.json
@@ -15,7 +15,7 @@
 			"enabled": "Activé",
 			"render_horizontally": "Afficher les suivis horizontalement",
 			"show_completed_achievements": "Afficher les distinctions obtenues",
-			"show_images": "Afficher l’Illustration des Distinctions",
+			"show_images": "Afficher l'Illustration des Distinctions",
 			"display_progress_as_percentage": "Afficher la Progression en Pourcentage",
 			"center_align_text": "Aligner au Centre tout le Texte des Suivis"
 		},


### PR DESCRIPTION
## Change 1 Explanation :
In French, the word "couleur" is considered feminine, so any adjectives or determiners used with it must be in the feminine form. Therefore, depending on what "current" refers to, it changes its form

## Change 2 Explanation :
The original version says "Control + Left Click to enter manually" To enter what? 
Ctrl + left click where? 
This correction adds that information.

## Bug 
also, there seems to be a unicode rendering issue at https://github.com/JdotCarver/MHWS-Achievement-Progress-Tracker/blob/0c8fb553afc4af7b46d7cda4f8ad5f63ac5d56a8/reframework/data/Achievement_Progress_Tracker/languages/fr-FR.json#L18
![image](https://github.com/user-attachments/assets/247e8bb7-26d9-46d4-bbe5-36201dcd998e)
